### PR TITLE
Update glycosylation-sites-UniCarbKB.json

### DIFF
--- a/glycosylation-sites-UniCarbKB.json
+++ b/glycosylation-sites-UniCarbKB.json
@@ -42,7 +42,7 @@
         "license": "https://creativecommons.org/licenses/by/4.0/"
     },
     "usability_domain":[
-        "List of human [taxid:9606] proteins with information on glycosylation sites from UniCarbKB database [https://academic.oup.com/nar/article/42/D1/D215/1052197, https://doi.org/10.1093/nar/gkt1128]"
+        "List of human [taxid:9606] proteins with information on glycosylation sites from UniCarbKB database [https://academic.oup.com/nar/article/42/D1/D215/1052197, https://doi.org/10.1093/nar/gkt1128]. The file also includes GlyTouCan accessions and UniCarbKB structure ids for associated glycan structures. The file also includes GlyTouCan accessions and UniCarbKB structure ids for associated glycan structures."
     ],
     "extension_domain":{
         "license":{
@@ -91,7 +91,7 @@
             },
             {
                 "step_number":2,
-                "name": "make-proteoform_glycosylation_sites_unicarbkb_glytoucan-csv-step2b.py",
+                "name": "make-proteoform_glycosylation_sites_unicarbkb_glytoucan-csv-step2a.py",
                 "description": "Python scripts for retrieving glycosylation type or linkage type through UniCarbKB structure webpage ",
 
                 "input_list":[


### PR DESCRIPTION
1. added "The file also includes GlyTouCan accessions and UniCarbKB structure ids for associated glycan structures" to usability domain.
2. change 2b to 2a.